### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: tests
 
 on: [workflow_dispatch, workflow_call, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mdusi/puppetchef/security/code-scanning/3](https://github.com/mdusi/puppetchef/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since this workflow is a basic CI pipeline that installs dependencies and runs tests, it only requires `contents: read` permissions. This will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
