### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/tests.yml
@@ -12,6 +15,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Potential fix for [https://github.com/mdusi/puppetchef/security/code-scanning/1](https://github.com/mdusi/puppetchef/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. At the root level, we will set `contents: read` as the default permission for all jobs. For the `release` job, we will explicitly define additional permissions required for its operations, such as `packages: write` (if needed for Docker operations) and `contents: read`. The `test` job will inherit the root-level permissions unless overridden in the external `tests.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
